### PR TITLE
Allow tarnovoconf under it-tour.bg

### DIFF
--- a/app/controllers/concerns/current_conference_methods.rb
+++ b/app/controllers/concerns/current_conference_methods.rb
@@ -10,8 +10,9 @@ module CurrentConferenceMethods
   def current_conference
     @current_conference ||= begin
       domain = request.domain
+      path = request.path
       domain = params[:domain] || 'varnaconf.com' if Rails.env.development?
-      Conference.find_for_domain(domain)
+      Conference.find_for_domain(domain, path)
     end
   end
 end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -8,8 +8,13 @@ class Conference < ActiveRecord::Base
   after_save :ensure_only_one_main, if: :main?
 
   class << self
-    def find_for_domain(domain)
-      where(domain: domain).first!
+    def find_for_domain(domain, path)
+      if defined?(path) && path != '/'
+        dom_with_path = domain + path
+        where(domain: dom_with_path).first!
+      else
+        where(domain: domain).first!
+      end
     end
 
     def regular

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,5 +39,7 @@ TourConf::Application.routes.draw do
   get 'archive/:year', to: 'events#show', as: :archive
   get 'archive/:year/photos', to: 'photos#index', as: :photos
 
+  get 'tarnovoconf',  to: 'conferences#show'
+
   root to: 'conferences#show'
 end


### PR DESCRIPTION
Налага ни се да имаме it-tour.bg/tarnovoconf, след като без да искаме изтървахме tarnovoconf.com да expire-не.

Направената промяна, дава възможност да се правят events, като имаме URLs от типа domain/path a не само domain.

Следващата промяна, ще направи кода, по-generic, така че съответните routes да станат валидни за всички domains а не само за it-tour.bg и също да можем да имаме едновременно plovdivconf.com & it-tour.bg/plovdivconf с един ред в events базата.